### PR TITLE
No longer loop for streams when a fatal error occurs.

### DIFF
--- a/src/quic/connection/mod.rs
+++ b/src/quic/connection/mod.rs
@@ -81,7 +81,8 @@ impl<T: DeserializeOwned + Serialize + Send + 'static> Connection<T> {
 			} {
 				let incoming = connecting.map_err(error::Connection);
 
-				if sender.send(incoming).is_err() {
+				let disconnected = incoming.is_err();
+				if sender.send(incoming).is_err() || disconnected {
 					// if there is no receiver, it means that we dropped the last
 					// `Connection`
 					break;


### PR DESCRIPTION
From my reading of the connection error types, they all indicate an error that should be considered a disconnect. This change ensures that this inner loop will exit if an error occurs.

In BonsaiDb this loop would occasionally get triggered into an infinite loop in a situation where I can't figure out where the `receiver` is still alive, yet the sender continues getting errors.