### PR TITLE
Fix high idle CPU usage

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,7 +43,6 @@ jobs:
           rustup default nightly
 
       - name: Run Clippy
-        continue-on-error: true
         run: |
           cargo clippy --workspace --all-targets --all-features -- -D warnings
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ test = []
 trust-dns = ["trust-dns-resolver"]
 
 [dependencies]
-allochronic-util = "0.0.1-dev-1"
 async-trait = "0.1"
 bincode = "1"
 bytes = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@
 	clippy::non_ascii_literal,
 	clippy::pattern_type_mismatch,
 	clippy::redundant_pub_crate,
-	clippy::unseparated_literal_suffix,
+	clippy::separated_literal_suffix,
 	clippy::shadow_reuse,
 	// Currently breaks async
 	clippy::shadow_same,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@
 	clippy::non_ascii_literal,
 	clippy::pattern_type_mismatch,
 	clippy::redundant_pub_crate,
-	clippy::separated_literal_suffix,
+	clippy::unseparated_literal_suffix,
 	clippy::shadow_reuse,
 	// Currently breaks async
 	clippy::shadow_same,

--- a/src/quic/connection/mod.rs
+++ b/src/quic/connection/mod.rs
@@ -84,8 +84,7 @@ impl<T: DeserializeOwned + Serialize + Send + 'static> Connection<T> {
 			} {
 				let incoming = connecting.map_err(error::Connection);
 
-				let disconnected = incoming.is_err();
-				if sender.send(incoming).is_err() || disconnected {
+				if sender.send(incoming).is_err() {
 					// if there is no receiver, it means that we dropped the last
 					// `Connection`
 					break;

--- a/src/quic/connection/receiver.rs
+++ b/src/quic/connection/receiver.rs
@@ -56,7 +56,7 @@ impl<T> Receiver<T> {
 			while let Some(message) = futures_util::select_biased! {
 				message = stream.next() => message.map(Message::Data),
 				shutdown = shutdown => shutdown.ok().map(|_| Message::Close),
-				complete => Some(Message::Close),
+				complete => None,
 			} {
 				match message {
 					Message::Data(message) => {

--- a/src/quic/connection/sender.rs
+++ b/src/quic/connection/sender.rs
@@ -47,7 +47,7 @@ impl<T: Serialize> Sender<T> {
 			while let Some(message) = futures_util::select_biased! {
 				message = receiver.next() => message.map(Message::Data),
 				shutdown = shutdown => shutdown.ok(),
-				complete => Some(Message::Finish),
+				complete => None,
 			} {
 				match message {
 					Message::Data(bytes) => stream_sender.write_chunk(bytes).await?,

--- a/src/quic/connection/sender.rs
+++ b/src/quic/connection/sender.rs
@@ -35,7 +35,6 @@ enum Message {
 impl<T: Serialize> Sender<T> {
 	/// Builds a new [`Sender`] from a raw [`quinn`] type. Spawns a task that
 	/// sends data into the stream.
-	#[allow(clippy::mut_mut)] // futures_util::select_biased internal usage
 	pub(super) fn new(mut stream_sender: SendStream) -> Self {
 		// sender channels
 		let (sender, receiver) = flume::unbounded();

--- a/src/quic/endpoint/builder/mod.rs
+++ b/src/quic/endpoint/builder/mod.rs
@@ -830,10 +830,7 @@ mod test {
 				&& error_code.to_string() == "the cryptographic handshake failed: error 120"));
 
 		// on protocol mismatch, the server receives nothing
-		assert!(matches!(
-			allochronic_util::poll(server.next()).await,
-			Poll::Pending
-		));
+		assert!(matches!(futures_util::poll!(server.next()), Poll::Pending));
 
 		Ok(())
 	}

--- a/src/quic/endpoint/mod.rs
+++ b/src/quic/endpoint/mod.rs
@@ -190,7 +190,6 @@ impl Endpoint {
 
 	/// Handle incoming connections. Accessed through [`Stream`] in
 	/// [`Endpoint`].
-	#[allow(clippy::mut_mut)] // futures_util::select_biased internal usage
 	async fn incoming(
 		incoming: quinn::Incoming,
 		sender: Sender<Connecting>,

--- a/src/quic/task.rs
+++ b/src/quic/task.rs
@@ -119,7 +119,6 @@ impl<R, S> Future for &Task<R, S> {
 
 #[cfg(test)]
 mod test {
-	use allochronic_util::select;
 	use anyhow::{Error, Result};
 	use futures_util::StreamExt;
 
@@ -153,9 +152,9 @@ mod test {
 		let task = Task::new(|mut shutdown| async move {
 			let mut receiver = receiver.into_stream();
 
-			while let Some(message) = select!(
-				message: &mut receiver => message,
-				_: &mut shutdown => None,
+			while let Some(message) = futures_util::select_biased!(
+				message = receiver.next() => message,
+				_ = &mut shutdown => None,
 			) {
 				// send back our messages
 				tester_sender.send(message)?;


### PR DESCRIPTION
This pull request migrates from allochronic::select to a basic solution using try_join to cancel early. I'm not really good at these types of operations, so there's probably a way to do this better with futures::select, but I don't really understand fusing.

This at least works -- and it minimizes the impact to two locations that can be refactored to use a better approach in the future.