### PR TITLE
Update for rustls 0.20

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ trust-dns = ["trust-dns-resolver"]
 async-trait = "0.1"
 bincode = "1"
 bytes = "1"
+ct-logs = "0.9"
 flume = "0.10"
 futures-channel = "0.3"
 futures-executor = "0.3"
@@ -34,6 +35,7 @@ rustls = { version = "0.20", default-features = false, features = [
 ] }
 serde = "1"
 thiserror = "1"
+time = "0.3"
 tokio = { version = "1", features = ["rt-multi-thread"] }
 trust-dns-resolver = { version = "0.21.0-alpha.4", default-features = false, optional = true, features = [
 	"dns-over-https-rustls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,32 +26,33 @@ futures-util = "0.3"
 if_chain = "1"
 parking_lot = { version = "0.11", features = ["send_guard"] }
 pin-project = "1"
-quinn = "0.7"
+quinn = "0.8"
 rcgen = { version = "0.8", default-features = false, optional = true }
 ring = "0.16"
-rustls = { version = "0.19", default-features = false, features = [
-	"dangerous_configuration"
+rustls = { version = "0.20", default-features = false, features = [
+	"dangerous_configuration",
 ] }
 serde = "1"
 thiserror = "1"
 tokio = { version = "1", features = ["rt-multi-thread"] }
-trust-dns-resolver = { version = "0.20", default-features = false, optional = true, features = [
+trust-dns-resolver = { version = "0.21.0-alpha.4", default-features = false, optional = true, features = [
 	"dns-over-https-rustls",
 	"dnssec-ring",
 	"tokio-runtime",
 ] }
 url = "2"
-webpki = { version = "0.21", default-features = false }
-webpki-roots = "0.21"
+webpki = { version = "0.22", default-features = false }
+webpki-roots = "0.22"
+rustls-native-certs = "0.6"
 x509-parser = "0.12"
 zeroize = { version = "1", features = ["zeroize_derive"] }
 
 [dev-dependencies]
 anyhow = "1"
 fabruic = { path = "", features = ["rcgen", "test", "trust-dns"] }
-quinn-proto = { version = "0.7", default-features = false }
+quinn-proto = { version = "0.8", default-features = false }
 tokio = { version = "1", features = ["macros"] }
-trust-dns-proto = "0.20"
+trust-dns-proto = "0.21.0-alpha.4"
 
 [profile.release]
 codegen-units = 1

--- a/src/quic/connection/connecting.rs
+++ b/src/quic/connection/connecting.rs
@@ -1,7 +1,7 @@
 //! Intermediate [`Connection`] object to query
 //! [`protocol`](Connecting::protocol).
 
-use quinn::NewConnection;
+use quinn::{crypto::rustls::HandshakeData, NewConnection};
 use serde::{de::DeserializeOwned, Serialize};
 
 use crate::{error, Connection};
@@ -26,7 +26,10 @@ impl Connecting {
 		self.0
 			.handshake_data()
 			.await
-			.map(|data| data.protocol)
+			.map(|data| {
+				data.downcast_ref::<HandshakeData>()
+					.and_then(|data| data.protocol.clone())
+			})
 			.map_err(error::Connecting)
 	}
 

--- a/src/quic/connection/receiver_stream.rs
+++ b/src/quic/connection/receiver_stream.rs
@@ -60,7 +60,7 @@ impl<M: DeserializeOwned> ReceiverStream<M> {
 		}
 	}
 
-	/// Calls [`RecvStream::stop`](quinn::generic::RecvStream::stop).
+	/// Calls [`RecvStream::stop`](RecvStream::stop).
 	///
 	/// # Errors
 	/// [`error::AlreadyClosed`] if it was already closed.

--- a/src/x509/certificate.rs
+++ b/src/x509/certificate.rs
@@ -52,23 +52,21 @@ impl Certificate {
 		// `quinn` uses
 		let _ = match EndEntityCert::try_from(certificate.as_slice()) {
 			Ok(parsed) => parsed,
-			Err(error) => {
+			Err(error) =>
 				return Err(error::Certificate {
 					error: CertificateError::WebPki(error),
 					certificate,
-				})
-			}
+				}),
 		};
 
 		// parse certificate with the `x509-parser, which is what `rcgen` uses
 		let (trailing, parsed) = match X509Certificate::from_der(&certificate) {
 			Ok((trailing, bytes)) => (trailing, bytes),
-			Err(error) => {
+			Err(error) =>
 				return Err(error::Certificate {
 					error: CertificateError::X509(error),
 					certificate,
-				})
-			}
+				}),
 		};
 
 		// don't allow trailing bytes

--- a/src/x509/certificate_chain.rs
+++ b/src/x509/certificate_chain.rs
@@ -93,23 +93,19 @@ impl CertificateChain {
 		self.0.get(index)
 	}
 
-	/// Convert from a [`quinn`] type.
-	pub(crate) fn from_quinn(certificate_chain: quinn::CertificateChain) -> Self {
-		Self(
-			certificate_chain
-				.into_iter()
-				.map(Certificate::from_rustls)
-				.collect(),
-		)
-	}
-
-	/// Convert into a type [`quinn`] can consume.
-	pub(crate) fn as_quinn(&self) -> quinn::CertificateChain {
-		quinn::CertificateChain::from_certs(self.0.iter().map(Certificate::as_quinn))
-	}
-
 	/// Convert into a type [`rustls`] can consume.
 	pub(crate) fn into_rustls(self) -> Vec<rustls::Certificate> {
 		self.0.into_iter().map(Certificate::into_rustls).collect()
+	}
+
+	/// Converts from a slice of rustls certificates with no validation.
+	pub(crate) fn from_rustls(certs: &[rustls::Certificate]) -> Self {
+		Self(
+			certs
+				.iter()
+				.cloned()
+				.map(Certificate::from_rustls)
+				.collect(),
+		)
 	}
 }

--- a/src/x509/mod.rs
+++ b/src/x509/mod.rs
@@ -3,7 +3,7 @@
 mod certificate;
 mod certificate_chain;
 pub mod private_key;
-use std::{convert::TryFrom, sync::Arc};
+use std::convert::TryFrom;
 
 pub use certificate::Certificate;
 pub use certificate_chain::CertificateChain;
@@ -130,7 +130,7 @@ impl KeyPair {
 	pub(crate) fn into_rustls(self) -> CertifiedKey {
 		CertifiedKey::new(
 			self.certificate_chain.into_rustls(),
-			Arc::new(self.private_key.into_rustls()),
+			self.private_key.into_rustls_signing_key(),
 		)
 	}
 }


### PR DESCRIPTION
This brings all dependencies up to rustls 0.20, and passes unit tests locally and in BonsaiDb.

This PR stacks on top of #33, so it's best to review it after that one has been merged.

The only notable change is for trust-dns: trust-dns fails with a `NoConnections` error if the additional option isn't specified. The other code changes are due to trust-dns adopting `#[non_exhaustive]`. 

*Edit: this is going to be addressed in the next release of trust-dns. Since we're aiming to release an update for BonsaiDb soon, I'm leaving it as-is, but will remember to update this when they release a new version.*