### PR TITLE
Added error for protocol mismatch

### DIFF
--- a/src/quic/connection/connecting.rs
+++ b/src/quic/connection/connecting.rs
@@ -32,7 +32,7 @@ impl Connecting {
 				data.downcast_ref::<HandshakeData>()
 					.and_then(|data| data.protocol.clone())
 			})
-			.map_err(error::Connecting)
+			.map_err(error::Connecting::from)
 	}
 
 	/// The peer's address. Clients may change addresses at will, e.g. when
@@ -59,6 +59,6 @@ impl Connecting {
 				     ..
 				 }| Connection::new(connection, bi_streams),
 			)
-			.map_err(error::Connecting)
+			.map_err(error::Connecting::from)
 	}
 }

--- a/src/quic/endpoint/builder/mod.rs
+++ b/src/quic/endpoint/builder/mod.rs
@@ -660,7 +660,7 @@ mod test {
 
 	use anyhow::Result;
 	use futures_util::StreamExt;
-	use quinn::{ConnectionClose, ConnectionError};
+	use quinn::ConnectionError;
 	use quinn_proto::TransportError;
 	use trust_dns_proto::error::ProtoErrorKind;
 	use trust_dns_resolver::error::ResolveErrorKind;
@@ -871,14 +871,7 @@ mod test {
 			.await;
 
 		// check result
-		assert!(matches!(
-			result,
-			Err(error::Connecting(ConnectionError::ConnectionClosed(ConnectionClose {
-				error_code,
-				frame_type: None,
-				reason
-			}))) if (reason.as_ref() == b"peer doesn't support any known protocol")
-				&& error_code.to_string() == "the cryptographic handshake failed: error 120"));
+		assert!(matches!(result, Err(error::Connecting::ProtocolMismatch)));
 
 		// on protocol mismatch, the server receives nothing
 		assert!(matches!(futures_util::poll!(server.next()), Poll::Pending));
@@ -1070,7 +1063,7 @@ mod test {
 		// check result
 		assert!(matches!(
 				result,
-				Err(error::Connecting(ConnectionError::TransportError(TransportError {
+				Err(error::Connecting::Connection(ConnectionError::TransportError(TransportError {
 					code,
 					frame: None,
 					reason

--- a/src/quic/endpoint/mod.rs
+++ b/src/quic/endpoint/mod.rs
@@ -732,7 +732,9 @@ mod test {
 				.await?
 				.accept::<()>()
 				.await,
-			Err(error::Connecting(ConnectionError::LocallyClosed))
+			Err(error::Connecting::Connection(
+				ConnectionError::LocallyClosed
+			))
 		));
 
 		// waiting for a new connection on a closed server shouldn't work
@@ -786,7 +788,7 @@ mod test {
 			.await;
 		assert!(matches!(
 			result,
-			Err(error::Connecting(ConnectionError::ConnectionClosed(
+			Err(error::Connecting::Connection(ConnectionError::ConnectionClosed(
 				ConnectionClose {
 					error_code: TransportErrorCode::CONNECTION_REFUSED,
 					frame_type: None,


### PR DESCRIPTION
This prevents users from needing to include quinn-proto to be able to do
this detection, and it ensures that before we ship a library update,
we're unit testing the strings that we currently have to match against.
