### PR TITLE
Added endpoint::Builder::set_reuse_address

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ webpki-roots = "0.22"
 rustls-native-certs = "0.6"
 x509-parser = "0.12"
 zeroize = { version = "1", features = ["zeroize_derive"] }
+socket2 = "0.4.7"
 
 [dev-dependencies]
 anyhow = "1"


### PR DESCRIPTION
This adds an option to enable SO_REUSEADDR, which provides a way to allow servers to rebind without waiting for the operating system to time the previous bind out.

Closes #50.

Thanks to @daxpedda for remembering that `SO_REUSEADDR` was a thing, and also helping me add this on Discord.