### PR TITLE
Upgrade quinn to 0.10

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,6 +33,22 @@ jobs:
           rustup toolchain install nightly --profile minimal --allow-downgrade
           cargo +nightly test --workspace --doc --all-features
 
+  msrv:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: "1.68.2"
+
+      - name: Run unit tests
+        run: |
+          cargo test --workspace --all-targets --all-features
+
   lint:
     runs-on: ubuntu-latest
 
@@ -47,12 +63,6 @@ jobs:
         run: |
           cargo clippy --workspace --all-targets --all-features -- -D warnings
 
-      - name: Run rustdoc
-        env:
-          RUSTDOCFLAGS: -D warnings
-        run: |
-          cargo doc --no-deps --document-private-items --workspace --all-features
-
   docs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
@@ -61,10 +71,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@nightly
+
       - name: Generate Docs
         run: |
           rustup install nightly --profile minimal
           cargo +nightly doc --no-deps --workspace --all-features
+        env:
+          RUSTDOCFLAGS: -D warnings
 
       - name: Deploy Docs
         uses: JamesIves/github-pages-deploy-action@releases/v4

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,6 +21,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
       - name: Run unit tests
         run: |
           cargo test --workspace --all-targets --all-features
@@ -37,10 +40,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Install nightly Rust
-        run: |
-          rustup toolchain install nightly --profile minimal --component clippy --allow-downgrade
-          rustup default nightly
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Run Clippy
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 Cargo.lock
 /profraw
 /coverage
+.vscode/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ repository = "https://github.com/khonsulabs/fabruic"
 keywords = ["quic"]
 categories = ["network-programming"]
 edition = "2021"
+rust-version = "1.68.2"
 
 [features]
 dangerous = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,10 +26,10 @@ futures-util = "0.3"
 if_chain = "1"
 parking_lot = { version = "0.12", features = ["send_guard"] }
 pin-project = "1"
-quinn = "0.8"
+quinn = "0.10.1"
 rcgen = { version = "0.10.0", default-features = false, optional = true }
 ring = "0.16"
-rustls = { version = "0.20", default-features = false, features = [
+rustls = { version = "0.21.1", default-features = false, features = [
 	"dangerous_configuration",
 ] }
 serde = { version = "1", features = ["derive"] }
@@ -42,17 +42,17 @@ trust-dns-resolver = { version = "0.22.0", default-features = false, optional = 
 	"tokio-runtime",
 ] }
 url = "2"
-webpki = { version = "0.22", default-features = false }
+webpki = { version = "0.22", default-features = false, features = ["std"] }
 webpki-roots = "0.23"
 rustls-native-certs = "0.6"
 x509-parser = "0.15.0"
 zeroize = { version = "1", features = ["zeroize_derive"] }
-socket2 = "0.4.7"
+socket2 = "0.5.3"
 
 [dev-dependencies]
 anyhow = "1"
 fabruic = { path = "", features = ["rcgen", "test"] }
-quinn-proto = { version = "0.8", default-features = false }
+quinn-proto = { version = "0.10.1", default-features = false }
 tokio = { version = "1", features = ["macros"] }
 trust-dns-proto = "0.22.0"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,5 @@
 #![deny(unsafe_code)]
-#![warn(
-	clippy::cargo,
-	clippy::nursery,
-	clippy::pedantic,
-	clippy::restriction,
-	future_incompatible,
-	rust_2018_idioms
-)]
+#![warn(clippy::cargo, clippy::pedantic, future_incompatible, rust_2018_idioms)]
 #![warn(
 	macro_use_extern_crate,
 	meta_variable_misuse,

--- a/src/quic/connection/connecting.rs
+++ b/src/quic/connection/connecting.rs
@@ -3,7 +3,7 @@
 
 use std::net::SocketAddr;
 
-use quinn::{crypto::rustls::HandshakeData, NewConnection};
+use quinn::crypto::rustls::HandshakeData;
 use serde::{de::DeserializeOwned, Serialize};
 
 use crate::{error, Connection};
@@ -52,13 +52,7 @@ impl Connecting {
 	) -> Result<Connection<T>, error::Connecting> {
 		self.0
 			.await
-			.map(
-				|NewConnection {
-				     connection,
-				     bi_streams,
-				     ..
-				 }| Connection::new(connection, bi_streams),
-			)
+			.map(Connection::new)
 			.map_err(error::Connecting::from)
 	}
 }

--- a/src/quic/connection/receiver_stream.rs
+++ b/src/quic/connection/receiver_stream.rs
@@ -76,8 +76,7 @@ impl<M: DeserializeOwned> ReceiverStream<M> {
 	/// # Errors
 	/// [`ReadError`] on failure to read from the [`RecvStream`].
 	fn poll(&mut self, cx: &mut Context<'_>) -> Poll<Result<Option<()>, ReadError>> {
-		self.stream
-			.read_chunk(usize::MAX, true)
+		std::pin::pin!(self.stream.read_chunk(usize::MAX, true))
 			.poll_unpin(cx)
 			.map_ok(|option| {
 				option.map(|Chunk { bytes, .. }| {

--- a/src/quic/connection/receiver_stream.rs
+++ b/src/quic/connection/receiver_stream.rs
@@ -4,7 +4,7 @@
 use std::{
 	marker::PhantomData,
 	mem::size_of,
-	pin::Pin,
+	pin::{pin, Pin},
 	task::{Context, Poll},
 };
 
@@ -76,7 +76,7 @@ impl<M: DeserializeOwned> ReceiverStream<M> {
 	/// # Errors
 	/// [`ReadError`] on failure to read from the [`RecvStream`].
 	fn poll(&mut self, cx: &mut Context<'_>) -> Poll<Result<Option<()>, ReadError>> {
-		std::pin::pin!(self.stream.read_chunk(usize::MAX, true))
+		pin!(self.stream.read_chunk(usize::MAX, true))
 			.poll_unpin(cx)
 			.map_ok(|option| {
 				option.map(|Chunk { bytes, .. }| {

--- a/src/quic/endpoint/builder/config.rs
+++ b/src/quic/endpoint/builder/config.rs
@@ -290,7 +290,7 @@ impl Config {
 		crypto.alpn_protocols = self.protocols.clone();
 
 		let mut client = ClientConfig::new(Arc::new(crypto));
-		client.transport_config(Arc::new(self.transport()));
+		let _client = client.transport_config(Arc::new(self.transport()));
 		Ok(client)
 	}
 }

--- a/src/quic/endpoint/builder/config.rs
+++ b/src/quic/endpoint/builder/config.rs
@@ -290,8 +290,7 @@ impl Config {
 		crypto.alpn_protocols = self.protocols.clone();
 
 		let mut client = ClientConfig::new(Arc::new(crypto));
-		client.transport = Arc::new(self.transport());
-
+		client.transport_config(Arc::new(self.transport()));
 		Ok(client)
 	}
 }

--- a/src/quic/endpoint/builder/mod.rs
+++ b/src/quic/endpoint/builder/mod.rs
@@ -515,6 +515,7 @@ impl Builder {
 	/// let endpoint = Builder::new().build()?;
 	/// # Ok(()) }
 	/// ```
+	#[allow(clippy::result_large_err)]
 	pub fn build(self) -> Result<Endpoint, error::Builder> {
 		match {
 			// build client
@@ -963,7 +964,7 @@ mod test {
 		}
 
 		// any other error or `Ok` should fail the test
-		panic!("unexpected result: {:?}", result)
+		panic!("unexpected result: {result:?}")
 	}
 
 	#[test]

--- a/src/quic/endpoint/mod.rs
+++ b/src/quic/endpoint/mod.rs
@@ -432,7 +432,7 @@ impl Endpoint {
 		// TODO: configurable executor
 		let address = {
 			// `ToSocketAddrs` needs a port
-			let domain = format!("{}:{}", domain, port);
+			let domain = format!("{domain}:{port}");
 			tokio::task::spawn_blocking(move || {
 				domain
 					.to_socket_addrs()
@@ -510,7 +510,7 @@ impl Endpoint {
 	pub async fn close_incoming(&self) -> Result<(), error::AlreadyClosed> {
 		if let Some(server) = &self.server {
 			let mut server = server.lock();
-			server.concurrent_connections(0);
+			let _config = server.concurrent_connections(0);
 			self.endpoint.set_server_config(Some(server.clone()));
 		}
 		self.task.close(()).await

--- a/src/x509/certificate_chain.rs
+++ b/src/x509/certificate_chain.rs
@@ -82,7 +82,6 @@ impl CertificateChain {
 	}
 
 	/// Returns an iterator over the [`CertificateChain`].
-	#[must_use]
 	pub fn iter(&self) -> Iter<'_, Certificate> {
 		self.0.iter()
 	}

--- a/src/x509/private_key.rs
+++ b/src/x509/private_key.rs
@@ -170,6 +170,6 @@ mod test {
 	#[test]
 	fn debug() {
 		let (_, private_key) = KeyPair::new_self_signed("test").into_parts();
-		assert_eq!("PrivateKey(\"[[redacted]]\")", format!("{:?}", private_key));
+		assert_eq!("PrivateKey(\"[[redacted]]\")", format!("{private_key:?}"));
 	}
 }


### PR DESCRIPTION
This PR is an attempt at updating to quinn 0.10.

As of the initial push, there are three unit tests that are failing:

- `quic::endpoint::test::close_incoming`: I cannot figure out how to get quinn to reject incoming connections, now that `IncomingBiStreams` isn't a thing anymore.
- `quic::endpoint::test::close`/`quic::endpoint::test::close_and_reuse`: time out due to not getting None from a closed server.

Closes #59, #60, #61.